### PR TITLE
I18n strings

### DIFF
--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * German language file for template
+ *
+ */
+
+$lang['btn_print']        = 'Drucken';
+

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * English language file for template
+ *
+ */
+
+$lang['btn_print']        = 'Print';

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * French language file for template
+ *
+ */
+
+$lang['btn_print']        = 'Imprimer';
+

--- a/main.php
+++ b/main.php
@@ -155,7 +155,7 @@ $showSidebar = $hasSidebar && ($ACT=='show');
 						?>
 						
 						<li onmouseup="window.print()">
-                            <a href="" class="action print"><span>Drucken</span></a><?php /* @todo: i18n */ ?>
+                            <a href="" class="action print"><span><?php echo tpl_getLang('btn_print'); ?></span></a>
                         </li>
 						
 						<?php


### PR DESCRIPTION
This removes 2 hard-coded strings in the template:
- "Speichern" now uses the core-provided localized string.
- "Drucken" now uses a template-provides localized string.
  - (such strings are provided in English, German and French)
